### PR TITLE
Fix for 64-bit cygwin

### DIFF
--- a/configure
+++ b/configure
@@ -52,8 +52,21 @@ case $(uname -s) in
     CYGWIN*)
         echo 'uname -s identifies a Cygwin environment.'
         IS_CYGWIN=1
-        UNIX_GPP=i686-pc-cygwin-g++
-        MINGW_GPP="i686-pc-mingw32-g++ i686-w64-mingw32-g++"
+        case $(uname -m) in
+            i686)
+                echo 'uname -m identifies a i686 environment.'
+                UNIX_GPP=i686-pc-cygwin-g++
+                MINGW_GPP="i686-pc-mingw32-g++ i686-w64-mingw32-g++"
+                ;;
+            x86_64)
+                echo 'uname -m identifies a x86_64 environment.'
+                UNIX_GPP=x86_64-pc-cygwin-g++
+                MINGW_GPP="x86_64-pc-mingw32-g++ x86_64-w64-mingw32-g++"
+                ;;
+            *)
+                echo 'Error: uname -m did not match either i686 or x86_64.'
+                exit 1
+                ;;
         UNIX_LDFLAGS_STATIC_LIBSTDCXX="-static-libgcc -static-libstdc++"
         ;;
     MINGW*)

--- a/configure
+++ b/configure
@@ -67,6 +67,7 @@ case $(uname -s) in
                 echo 'Error: uname -m did not match either i686 or x86_64.'
                 exit 1
                 ;;
+        esac
         UNIX_LDFLAGS_STATIC_LIBSTDCXX="-static-libgcc -static-libstdc++"
         ;;
     MINGW*)


### PR DESCRIPTION
Updated configure to find 64-bit compilers on a 64-bit cygwin install.