### PR TITLE
Set the appropriate locale

### DIFF
--- a/unix-adapter/main.cc
+++ b/unix-adapter/main.cc
@@ -357,6 +357,7 @@ int main(int argc, char *argv[])
         return 0;
     }
 
+    setlocale(LC_ALL, "");
     setupWin32Environment();
 
     winsize sz;


### PR DESCRIPTION
By calling `setlocale(LC_ALL, "");`, we give the user a chance to
override the ASCII-only default so that non-ASCII arguments are
converted into UTF-16 properly, which is required to pass them
correctly to the actual Win32 executable.

This is necessary because POSIX dictates that we start up with the C
locale, ignoring all environment variables, until that `setlocale()`
call.

This fixes https://github.com/git-for-windows/git/issues/412

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>