### PR TITLE
Continuous Integration: Add build configure for Tea CI.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,17 @@
+# Build configure for https://www.tea-ci.org (fork of Drone CI with Msys2 support)
+build:
+  image: teaci/msys$$arch
+  pull: true
+  shell: msys$$arch
+  commands:
+    - pacman -S --needed --noconfirm --noprogressbar mingw-w64-cross-gcc mingw-w64-cross-crt-git
+    - ./configure
+    - make
+    - make tests
+    - build/trivial_test.exe
+    - mintty --log - --exec build/winpty.exe cmd /c ver | grep Windows
+
+matrix:
+  arch:
+    - 64
+    - 32


### PR DESCRIPTION
Hi,

I added a build configure for winpty, see an example here https://tea-ci.org/fracting/winpty/1

I know you are working on continuous integration on the Appveyor branch, at the same time, I'd like to proposal one more continuous integration with Tea CI, which builds Windows application on Wine ;)

See http://docs.tea-ci.org/usage/overview/ for some introduction.

Please let me know how do you think, thanks!