### PR TITLE
Add winpty_get_console_process_list

### DIFF
--- a/src/agent/Agent.cc
+++ b/src/agent/Agent.cc
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <algorithm>
 #include <string>
 #include <utility>
 #include <vector>
@@ -439,11 +440,7 @@ void Agent::handleGetConsoleProcessListPacket(ReadBuffer &packet)
     // The process list can change while we're trying to read it
     while (processList.size() < processCount) {
         // Multiplying by two caps the number of iterations
-        const int newSize = processList.size() * 2;
-        if (newSize <= processList.size()) { // Ensure we fail when new size overflows
-            processCount = 0;
-            break;
-        }
+        const auto newSize = std::max<DWORD>(processList.size() * 2, processCount);
         processList.resize(newSize);
         processCount = GetConsoleProcessList(&processList[0], processList.size());
     }

--- a/src/agent/Agent.h
+++ b/src/agent/Agent.h
@@ -59,6 +59,7 @@ private:
     void writePacket(WriteBuffer &packet);
     void handleStartProcessPacket(ReadBuffer &packet);
     void handleSetSizePacket(ReadBuffer &packet);
+    void handleGetConsoleProcessListPacket(ReadBuffer &packet);
     void pollConinPipe();
 
 protected:

--- a/src/include/winpty.h
+++ b/src/include/winpty.h
@@ -218,6 +218,11 @@ WINPTY_API BOOL
 winpty_set_size(winpty_t *wp, int cols, int rows,
                 winpty_error_ptr_t *err /*OPTIONAL*/);
 
+/* Gets a list of processes attached to the console. */
+WINPTY_API int
+winpty_get_console_process_list(winpty_t *wp, int *processList, const int processCount,
+                                winpty_error_ptr_t *err /*OPTIONAL*/);
+
 /* Frees the winpty_t object and the OS resources contained in it.  This
  * call breaks the connection with the agent, which should then close its
  * console, terminating the processes attached to it.

--- a/src/shared/AgentMsg.h
+++ b/src/shared/AgentMsg.h
@@ -26,6 +26,7 @@ struct AgentMsg
     enum Type {
         StartProcess,
         SetSize,
+        GetConsoleProcessList,
     };
 };
 


### PR DESCRIPTION
For a better implementation of Microsoft/vscode#30152 and Microsoft/vscode#29926 we need a list of processes attached to the console (instead of using a full process tree).

[`GetConsoleProcessList`](https://docs.microsoft.com/en-us/windows/console/getconsoleprocesslist) needs to be called from a process attached to the console. Since winpty-agent is already attached to it, it seems to be a good place to call it from.