### PR TITLE
Disable outputing title escape sequences when WINPTY_FLAG_PLAIN_OUTPUT sets

### DIFF
--- a/src/agent/Agent.cc
+++ b/src/agent/Agent.cc
@@ -602,9 +602,11 @@ void Agent::syncConsoleTitle()
 {
     std::wstring newTitle = m_console.title();
     if (newTitle != m_currentTitle) {
-        std::string command = std::string("\x1b]0;") +
-                utf8FromWide(newTitle) + "\x07";
-        m_conoutPipe->write(command.c_str());
+        if (!m_plainMode && !m_conoutPipe->isClosed()) {
+            std::string command = std::string("\x1b]0;") +
+                    utf8FromWide(newTitle) + "\x07";
+            m_conoutPipe->write(command.c_str());
+        }
         m_currentTitle = newTitle;
     }
 }


### PR DESCRIPTION
Thnaks for your great work.

When i using winpty under Plain mode . it outputs title escape sequences.
Although we could use regression expression to filter it out .it is pretty confusing.