### PR TITLE
Adds Cygwin agent (mainly for Visual Studio Code)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ install-bin : all
 	install -m 755 -p -s build/$(UNIX_ADAPTER_EXE) $(PREFIX)/bin
 	install -m 755 -p -s build/winpty.dll $(PREFIX)/bin
 	install -m 755 -p -s build/winpty-agent.exe $(PREFIX)/bin
+	install -m 755 -p -s build/winpty-cygwin-agent.exe $(PREFIX)/bin
 
 .PHONY : install-debugserver
 install-debugserver : all

--- a/README.md
+++ b/README.md
@@ -116,6 +116,33 @@ To run a Windows console program in `mintty` or Cygwin `sshd`, prepend
     30
     PS C:\rprichard\proj\winpty> exit
 
+### Building the Cygwin adapter
+
+In the project directory, run `./configure`, then `make`, then `make install`.
+By default, winpty is installed into `/usr/local`.  Pass `PREFIX=<path>` to
+`make install` to override this default.
+
+### Using the Cygwin adapter inside Visual Studio Code
+
+The integrated terminal in Visual Studio Code has numerous flaws[[11](#r1)] on Windows and winpty
+versions lacking ConPTY support, which covers the lion's share of installations, as
+ConPTY is only available on recent Windows 10 builds. Since winpty is ordinarily obliged to
+interact with Cygwin processes' terminal via Windows' deficient console APIs, the Cygwin
+adapter instead leverages Cygwin's native PTY implementation. This provides a direct
+interface between `xterm.js` and Cygwin processes, addressing most of those flaws
+and rendering the terminal usable.  
+  
+To obtain a fully functional integrated Cygwin terminal inside Visual Studio Code,
+copy `/usr/local/bin/winpty-cygwin-agent.exe` (see above) as `winpty-agent.exe` into
+the `Microsoft VS Code\resources\app\node_modules.asar.unpacked\node-pty\build\Release`
+directory inside either `%ProgramFiles%` or `%ProgramFiles(x86)%` on 64-bit and
+32-bit Windows respectively, preferably backing up the original `winpty-agent.exe`
+image first.  
+Ensure that the Cygwin installation is in `%Path%` either globally or for Visual
+Studio Code.
+
+``[1]`` <a href="https://github.com/microsoft/vscode/issues/45693" id="r1">Windows terminal issues caused by winpty · Issue #45693 · microsoft/vscode</a>
+
 ## Embedding winpty / MSVC compilation
 
 See `src/include/winpty.h` for the prototypes of functions exported by

--- a/src/cygwin-agent/Agent.cc
+++ b/src/cygwin-agent/Agent.cc
@@ -1,0 +1,349 @@
+// Copyright (c) 2011-2015 Ryan Prichard
+// Copyright (c) 2019 Lucio Andrés Illanes Albornoz <lucio@lucioillanes.de>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#include "Agent.h"
+
+#include <windows.h>
+
+#include <stdint.h>
+#include <sys/ioctl.h>
+
+#include <string>
+#include <vector>
+
+#include "../include/winpty_constants.h"
+
+#include "../shared/AgentMsg.h"
+#include "../shared/Buffer.h"
+#include "../shared/DebugClient.h"
+#include "../shared/GenRandom.h"
+#include "../shared/StringBuilder.h"
+#include "../shared/StringUtil.h"
+#include "../shared/WinptyAssert.h"
+
+#include "AgentCygwinPty.h"
+#include "NamedPipe.h"
+
+// (from src/agent/Scraper.h)
+const int MAX_CONSOLE_HEIGHT = 2000, MAX_CONSOLE_WIDTH = 2500;
+
+namespace {
+
+static HANDLE duplicateHandle(HANDLE h) {
+    HANDLE ret = nullptr;
+    if (!DuplicateHandle(
+            GetCurrentProcess(), h,
+            GetCurrentProcess(), &ret,
+            0, FALSE, DUPLICATE_SAME_ACCESS)) {
+        ASSERT(false && "DuplicateHandle failed!");
+    }
+    return ret;
+}
+
+// It's safe to truncate a handle from 64-bits to 32-bits, or to sign-extend it
+// back to 64-bits.  See the MSDN article, "Interprocess Communication Between
+// 32-bit and 64-bit Applications".
+// https://msdn.microsoft.com/en-us/library/windows/desktop/aa384203.aspx
+static int64_t int64FromHandle(HANDLE h) {
+    return static_cast<int64_t>(reinterpret_cast<intptr_t>(h));
+}
+
+static inline WriteBuffer newPacket() {
+    WriteBuffer packet;
+    packet.putRawValue<uint64_t>(0); // Reserve space for size.
+    return packet;
+}
+
+} // anonymous namespace
+
+Agent::Agent(LPCWSTR controlPipeName,
+             uint64_t agentFlags,
+             int mouseMode,
+             int initialCols,
+             int initialRows) :
+    m_useConerr((agentFlags & WINPTY_FLAG_CONERR) != 0),
+    m_plainMode((agentFlags & WINPTY_FLAG_PLAIN_OUTPUT) != 0),
+    m_mouseMode(mouseMode)
+{
+    trace("Agent::Agent entered");
+
+    ASSERT(initialCols >= 1 && initialRows >= 1);
+    initialCols = std::min(initialCols, MAX_CONSOLE_WIDTH);
+    initialRows = std::min(initialRows, MAX_CONSOLE_HEIGHT);
+    m_pty_winp.ws_row = initialRows;
+    m_pty_winp.ws_col = initialCols;
+    m_pty = std::unique_ptr<AgentCygwinPty>(new AgentCygwinPty());
+
+    m_controlPipe = &connectToControlPipe(controlPipeName);
+    m_coninPipe = &createDataServerPipe(false, L"conin");
+    m_conoutPipe = &createDataServerPipe(true, L"conout");
+    if (m_useConerr) {
+        m_conerrPipe = &createDataServerPipe(true, L"conerr");
+    }
+
+    // Send an initial response packet to winpty.dll containing pipe names.
+    {
+        auto setupPacket = newPacket();
+        setupPacket.putWString(m_coninPipe->name());
+        setupPacket.putWString(m_conoutPipe->name());
+        if (m_useConerr) {
+            setupPacket.putWString(m_conerrPipe->name());
+        }
+        writePacket(setupPacket);
+    }
+}
+
+Agent::~Agent()
+{
+    trace("Agent::~Agent entered");
+    trace("Closing CONOUT pipe (auto-shutdown)");
+    m_conoutPipe->closePipe();
+    if (m_conerrPipe != nullptr) {
+        trace("Closing CONERR pipe (auto-shutdown)");
+        m_conerrPipe->closePipe();
+    }
+    shutdown();
+    agentShutdown();
+    if (m_childProcess != NULL) {
+        CloseHandle(m_childProcess);
+    }
+    m_pty.reset();
+}
+
+NamedPipe &Agent::connectToControlPipe(LPCWSTR pipeName)
+{
+    NamedPipe &pipe = createNamedPipe();
+    pipe.connectToServer(pipeName, NamedPipe::OpenMode::Duplex);
+    pipe.setReadBufferSize(64 * 1024);
+    return pipe;
+}
+
+// Returns a new server named pipe.  It has not yet been connected.
+NamedPipe &Agent::createDataServerPipe(bool write, const wchar_t *kind)
+{
+    const auto name =
+        (WStringBuilder(128)
+            << L"\\\\.\\pipe\\winpty-"
+            << kind << L'-'
+            << GenRandom().uniqueName()).str_moved();
+    NamedPipe &pipe = createNamedPipe();
+    pipe.openServerPipe(
+        name.c_str(),
+        write ? NamedPipe::OpenMode::Writing
+              : NamedPipe::OpenMode::Reading,
+        write ? 8192 : 0,
+        write ? 0 : 256);
+    if (!write) {
+        pipe.setReadBufferSize(64 * 1024);
+    }
+    return pipe;
+}
+
+HANDLE Agent::getPtyEventHandle()
+{
+    if (m_pty) {
+        return m_pty->m_inputWorker.m_event.get();
+    } else {
+        return nullptr;
+    }
+}
+
+void Agent::handleGetConsoleProcessListPacket(ReadBuffer &packet)
+{
+    packet.assertEof();
+
+    auto processList = std::vector<DWORD>(1);
+    auto processCount = 1u;
+
+    // FIXME
+    processList[0] = m_pty->m_pid;
+    auto reply = newPacket();
+    reply.putInt32(processCount);
+    for (DWORD i = 0; i < processCount; i++) {
+        reply.putInt32(processList[i]);
+    }
+    writePacket(reply);
+}
+
+void Agent::handlePacket(ReadBuffer &packet)
+{
+    const int type = packet.getInt32();
+    switch (type) {
+    case AgentMsg::StartProcess:
+        handleStartProcessPacket(packet);
+        break;
+    case AgentMsg::SetSize:
+        // TODO: I think it might make sense to collapse consecutive SetSize
+        // messages.  i.e. The terminal process can probably generate SetSize
+        // messages faster than they can be processed, and some GUIs might
+        // generate a flood of them, so if we can read multiple SetSize packets
+        // at once, we can ignore the early ones.
+        handleSetSizePacket(packet);
+        break;
+    case AgentMsg::GetConsoleProcessList:
+        handleGetConsoleProcessListPacket(packet);
+        break;
+    default:
+        trace("Unrecognized message, id:%d", type);
+    }
+}
+
+void Agent::handleSetSizePacket(ReadBuffer &packet)
+{
+    const int cols = packet.getInt32();
+    const int rows = packet.getInt32();
+    packet.assertEof();
+    m_pty_winp.ws_col = cols;
+    m_pty_winp.ws_row = rows;
+    ioctl(m_pty->m_fd, TIOCSWINSZ, &m_pty_winp);
+    auto reply = newPacket();
+    writePacket(reply);
+}
+
+void Agent::handleStartProcessPacket(ReadBuffer &packet)
+{
+    ASSERT(m_childProcess == nullptr);
+
+    const uint64_t spawnFlags = packet.getInt64();
+    const bool wantProcessHandle = packet.getInt32() != 0;
+    const bool wantThreadHandle = packet.getInt32() != 0;
+    const auto program = packet.getWString();
+    const auto cmdline = packet.getWString();
+    const auto cwd = packet.getWString();
+    const auto env = packet.getWString();
+    const auto desktop = packet.getWString();
+    packet.assertEof();
+
+    auto cmdlineV = vectorWithNulFromString(cmdline);
+    auto desktopV = vectorWithNulFromString(desktop);
+    auto envV = vectorFromString(env);
+
+    HANDLE hProcess, hThread;
+    int lastError = 0;
+    BOOL success = TRUE;
+
+    if ((lastError = m_pty->fork(cmdline, m_pty_winp, &hProcess, &hThread)) != 0) {
+        success = FALSE;
+    }
+    auto reply = newPacket();
+    if (success) {
+        int64_t replyProcess = 0;
+        int64_t replyThread = 0;
+        if (wantProcessHandle) {
+            replyProcess = int64FromHandle(duplicateHandle(hProcess));
+        }
+        if (wantThreadHandle) {
+            replyThread = int64FromHandle(duplicateHandle(hThread));
+        }
+        CloseHandle(hThread);
+        m_childProcess = hProcess;
+        m_autoShutdown = (spawnFlags & WINPTY_SPAWN_FLAG_AUTO_SHUTDOWN) != 0;
+        m_exitAfterShutdown = (spawnFlags & WINPTY_SPAWN_FLAG_EXIT_AFTER_SHUTDOWN) != 0;
+        reply.putInt32(static_cast<int32_t>(StartProcessResult::ProcessCreated));
+        reply.putInt64(replyProcess);
+        reply.putInt64(replyThread);
+    } else {
+        reply.putInt32(static_cast<int32_t>(StartProcessResult::CreateProcessFailed));
+        reply.putInt32(lastError);
+    }
+    writePacket(reply);
+}
+
+void Agent::onPipeIo(NamedPipe &namedPipe)
+{
+    if (&namedPipe == m_coninPipe) {
+        pollConinPipe();
+    } else if (&namedPipe == m_controlPipe) {
+        pollControlPipe();
+    }
+}
+
+bool Agent::onPtyIo()
+{
+    const char *buf; size_t buf_len = 0;
+    bool rc = false, status;
+
+    if (m_pty) {
+        status = m_pty->read(&buf, &buf_len);
+        if (buf_len > 0) {
+            m_conoutPipe->write(buf, buf_len), rc = true; delete buf;
+        }
+        if (!status) {
+            if (m_childProcess != NULL) {
+                CloseHandle(m_childProcess);
+            }
+            m_pty.reset();
+            shutdown(), rc = true;
+        }
+    }
+    return rc;
+}
+
+void Agent::pollConinPipe()
+{
+    if (m_pty) {
+        const std::string newData = m_coninPipe->readAllToString();
+        m_pty->write(newData.c_str(), newData.size());
+    }
+}
+
+void Agent::pollControlPipe()
+{
+    if (m_controlPipe->isClosed()) {
+        trace("Agent exiting (control pipe is closed)");
+        shutdown();
+        return;
+    }
+
+    while (true) {
+        uint64_t packetSize = 0;
+        const auto amt1 =
+            m_controlPipe->peek(&packetSize, sizeof(packetSize));
+        if (amt1 < sizeof(packetSize)) {
+            break;
+        }
+        ASSERT(packetSize >= sizeof(packetSize) && packetSize <= SIZE_MAX);
+        if (m_controlPipe->bytesAvailable() < packetSize) {
+            if (m_controlPipe->readBufferSize() < packetSize) {
+                m_controlPipe->setReadBufferSize(packetSize);
+            }
+            break;
+        }
+        std::vector<char> packetData;
+        packetData.resize(packetSize);
+        const auto amt2 = m_controlPipe->read(packetData.data(), packetSize);
+        ASSERT(amt2 == packetSize);
+        try {
+            ReadBuffer buffer(std::move(packetData));
+            buffer.getRawValue<uint64_t>(); // Discard the size.
+            handlePacket(buffer);
+        } catch (const ReadBuffer::DecodeError&) {
+            ASSERT(false && "Decode error");
+        }
+    }
+}
+
+void Agent::writePacket(WriteBuffer &packet)
+{
+    const auto &bytes = packet.buf();
+    packet.replaceRawValue<uint64_t>(0, bytes.size());
+    m_controlPipe->write(bytes.data(), bytes.size());
+}

--- a/src/cygwin-agent/Agent.h
+++ b/src/cygwin-agent/Agent.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2011-2015 Ryan Prichard
+// Copyright (c) 2019 Lucio Andrés Illanes Albornoz <lucio@lucioillanes.de>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#ifndef AGENT_H
+#define AGENT_H
+
+#include <windows.h>
+
+#include <stdint.h>
+#include <termios.h>
+
+#include <memory>
+#include <string>
+
+#include "../agent/DsrSender.h"
+#include "EventLoop.h"
+
+class AgentCygwinPty;
+class NamedPipe;
+class ReadBuffer;
+class WriteBuffer;
+
+class Agent : public EventLoop, public DsrSender
+{
+public:
+    Agent(LPCWSTR controlPipeName,
+          uint64_t agentFlags,
+          int mouseMode,
+          int initialCols,
+          int initialRows);
+    virtual ~Agent();
+
+private:
+    NamedPipe &connectToControlPipe(LPCWSTR pipeName);
+    NamedPipe &createDataServerPipe(bool write, const wchar_t *kind);
+
+private:
+    void pollControlPipe();
+    void handlePacket(ReadBuffer &packet);
+    void writePacket(WriteBuffer &packet);
+    void handleStartProcessPacket(ReadBuffer &packet);
+    void handleSetSizePacket(ReadBuffer &packet);
+    void handleGetConsoleProcessListPacket(ReadBuffer &packet);
+    void pollConinPipe();
+
+protected:
+    virtual HANDLE getPtyEventHandle() override;
+    virtual bool onPtyIo() override;
+    virtual void onPipeIo(NamedPipe &namedPipe) override;
+
+private:
+    const bool m_useConerr;
+    const bool m_plainMode;
+    const int m_mouseMode;
+    NamedPipe *m_controlPipe = nullptr;
+    NamedPipe *m_coninPipe = nullptr;
+    NamedPipe *m_conoutPipe = nullptr;
+    NamedPipe *m_conerrPipe = nullptr;
+    bool m_autoShutdown = false;
+    bool m_exitAfterShutdown = false;
+    bool m_closingOutputPipes = false;
+    HANDLE m_childProcess = nullptr;
+    std::unique_ptr<AgentCygwinPty> m_pty;
+    struct winsize m_pty_winp;
+};
+
+#endif // AGENT_H

--- a/src/cygwin-agent/AgentCreateDesktop.cc
+++ b/src/cygwin-agent/AgentCreateDesktop.cc
@@ -1,0 +1,84 @@
+// Copyright (c) 2016 Ryan Prichard
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#include "AgentCreateDesktop.h"
+
+#include "../shared/BackgroundDesktop.h"
+#include "../shared/Buffer.h"
+#include "../shared/DebugClient.h"
+#include "../shared/StringUtil.h"
+
+#include "EventLoop.h"
+#include "NamedPipe.h"
+
+namespace {
+
+static inline WriteBuffer newPacket() {
+    WriteBuffer packet;
+    packet.putRawValue<uint64_t>(0); // Reserve space for size.
+    return packet;
+}
+
+class CreateDesktopLoop : public EventLoop {
+public:
+    CreateDesktopLoop(LPCWSTR controlPipeName);
+
+protected:
+    virtual void onPipeIo(NamedPipe &namedPipe) override;
+
+private:
+    void writePacket(WriteBuffer &packet);
+
+    BackgroundDesktop m_desktop;
+    NamedPipe &m_pipe;
+};
+
+CreateDesktopLoop::CreateDesktopLoop(LPCWSTR controlPipeName) :
+        m_pipe(createNamedPipe()) {
+    m_pipe.connectToServer(controlPipeName, NamedPipe::OpenMode::Duplex);
+    auto packet = newPacket();
+    packet.putWString(m_desktop.desktopName());
+    writePacket(packet);
+}
+
+void CreateDesktopLoop::writePacket(WriteBuffer &packet) {
+    const auto &bytes = packet.buf();
+    packet.replaceRawValue<uint64_t>(0, bytes.size());
+    m_pipe.write(bytes.data(), bytes.size());
+}
+
+void CreateDesktopLoop::onPipeIo(NamedPipe &namedPipe) {
+    if (m_pipe.isClosed()) {
+        shutdown();
+    }
+}
+
+} // anonymous namespace
+
+void handleCreateDesktop(LPCWSTR controlPipeName) {
+    try {
+        CreateDesktopLoop loop(controlPipeName);
+        loop.run();
+        trace("Agent exiting...");
+    } catch (const WinptyException &e) {
+        trace("handleCreateDesktop: internal error: %s",
+            utf8FromWide(e.what()).c_str());
+    }
+}

--- a/src/cygwin-agent/AgentCreateDesktop.h
+++ b/src/cygwin-agent/AgentCreateDesktop.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2016 Ryan Prichard
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#ifndef AGENT_CREATE_DESKTOP_H
+#define AGENT_CREATE_DESKTOP_H
+
+#include <windows.h>
+
+void handleCreateDesktop(LPCWSTR controlPipeName);
+
+#endif //  AGENT_CREATE_DESKTOP_H

--- a/src/cygwin-agent/AgentCygwinPty.cc
+++ b/src/cygwin-agent/AgentCygwinPty.cc
@@ -1,0 +1,352 @@
+// Copyright (c) 2011-2015 Ryan Prichard
+// Copyright (c) 2019 Lucio Andrés Illanes Albornoz <lucio@lucioillanes.de>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#define _GNU_SOURCE // for ptsname(3)
+#include "AgentCygwinPty.h"
+
+#include <pty.h>
+#include <unistd.h>
+#include <utmp.h>
+#include <sys/cygwin.h>
+
+#include "../shared/DebugClient.h"
+
+static OwnedHandle createEvent();
+static void ptyForkChildRoutine(const std::wstring cmdline);
+static bool ptyForkParentRoutine(int pty_fd, pid_t pty_pid, HANDLE *phProcess, HANDLE *phThread);
+static char *wcsToMbs(const wchar_t *text);
+
+// manual reset, initially unset
+static OwnedHandle createEvent() {
+    HANDLE ret = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    ASSERT(ret != nullptr && "CreateEventW failed");
+    return OwnedHandle(ret);
+}
+
+// (based on mintty/src/child.c:child_create())
+static void ptyForkChildRoutine(const std::wstring cmdline)
+{
+    struct termios attr;
+    int exec_argcw; wchar_t **exec_argvw = NULL;
+    const char **exec_argv = NULL;
+    int rc;
+
+    // Reset signals; mimick login's behavior by disabling the job control signals
+    for (auto signo : {SIGHUP, SIGINT, SIGQUIT, SIGTERM, SIGCHLD}) {
+        signal(signo, SIG_DFL);
+    }
+    for (auto signo : {SIGTSTP, SIGTTIN, SIGTTOU}) {
+        signal(signo, SIG_IGN);
+    }
+
+    // Terminal line settings
+    tcgetattr(0, &attr);
+    attr.c_cc[VERASE] = CTRL('H');
+    attr.c_iflag |= IMAXBEL | IUTF8 | IXANY;
+    attr.c_lflag |= ECHOCTL | ECHOE | ECHOK | ECHOKE;
+    tcsetattr(0, TCSANOW, &attr);
+
+    // Build exec_argv & invoke command
+    if ((exec_argvw = CommandLineToArgvW(cmdline.c_str(), &exec_argcw))) {
+        exec_argv = new const char *[exec_argcw + 1]();
+        for (int exec_argc = 0; exec_argc < exec_argcw; exec_argc++) {
+            exec_argv[exec_argc] = wcsToMbs(exec_argvw[exec_argc]);
+            TRACE("exec_argv[%d]=%s", exec_argc, exec_argv[exec_argc]);
+        }
+        LocalFree(exec_argvw);
+        execvp(exec_argv[0], (char* const*)exec_argv);
+        TRACE("execvp() failed, errno=%d", errno);
+        fflush(stderr), rc = 126;
+    } else {
+        TRACE("CommandLineToArgvW() returned NULL, GetLastError()=%d", GetLastError());
+        rc = 127;
+    }
+
+    for (int exec_argc = 0; exec_argc < exec_argcw; exec_argc++) {
+        delete exec_argv[exec_argc];
+    }
+    delete exec_argv;
+    exit(rc);
+}
+
+// (based on mintty/src/child.c:child_create())
+static bool ptyForkParentRoutine(int pty_fd, pid_t pty_pid, HANDLE *phProcess, HANDLE *phThread)
+{
+    const char *dev, *login_name;
+    HANDLE hProcess = NULL, hThread = NULL;
+    bool rc = false;
+    struct utmp ut;
+    int winpid;
+
+    winpid = cygwin_internal(CW_CYGWIN_PID_TO_WINPID, pty_pid);
+    hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, winpid);
+    hThread = OpenThread(THREAD_ALL_ACCESS, FALSE, winpid);
+    if ((dev = ptsname(pty_fd))) {
+        memset(&ut, 0, sizeof(ut));
+        if (strncmp(dev, "/dev/", 5) == 0) {
+            dev += 5;
+        }
+        strlcpy(ut.ut_line, dev, sizeof(ut.ut_line));
+
+        if (strncmp(&dev[1], "ty", 2) == 0) {
+            dev += 1 + 2;
+        }
+        else if (strncmp(dev, "pts/", 4) == 0) {
+            dev += 4;
+        }
+        strncpy(ut.ut_id, dev, sizeof(ut.ut_id));
+
+        gethostname(ut.ut_host, sizeof(ut.ut_host));
+        ut.ut_pid = pty_pid, ut.ut_time = time(0), ut.ut_type = USER_PROCESS;
+        if ((login_name = getlogin())) {
+            strlcpy(ut.ut_user, login_name ? login_name : "?", sizeof(ut.ut_user));
+            login(&ut), rc = true;
+        } else {
+            TRACE("getlogin() failed, errno=%d", errno);
+        }
+    } else {
+        TRACE("ptsname() failed, errno=%d", errno);
+    }
+    if (rc) {
+        *phProcess = hProcess, *phThread = hThread;
+    }
+    return rc;
+}
+
+static char *wcsToMbs(const wchar_t *text)
+{
+    // Calling wcstombs with a NULL first argument seems to be broken on MSYS.
+    // Instead of returning the size of the converted string, it returns 0.
+    // Using wcslen(text) * 3 is big enough for UTF-8 and probably other
+    // encodings.  For UTF-8, codepoints that fit in a single wchar
+    // (U+0000 to U+FFFF) are encoded using 1-3 bytes.  The remaining code
+    // points needs two wchar's and are encoded using 4 bytes.
+    size_t maxLen = wcslen(text) * 3 + 1;
+    char *ret = new char[maxLen];
+    size_t len = wcstombs(ret, text, maxLen);
+    if (len == (size_t)-1 || len >= maxLen) {
+        delete [] ret;
+        return NULL;
+    } else {
+        return ret;
+    }
+}
+
+void AgentCygwinPty::close()
+{
+    if (m_fd != -1) {
+        ::close(m_fd), m_fd = -1;
+    }
+    m_inputWorker.cancelWorker(), m_outputWorker.cancelWorker();
+    if (m_pid != -1) {
+        kill(m_pid, SIGTERM), kill(m_pid, SIGKILL), m_pid = -1;
+    }
+}
+
+int AgentCygwinPty::fork(const std::wstring cmdline, struct winsize pty_winp, HANDLE *phProcess, HANDLE *phThread)
+{
+    HANDLE hProcess, hThread;
+    int pty_fd; pid_t pty_pid;
+    int status = 0;
+
+    switch ((pty_pid = forkpty(&pty_fd, 0, 0, &pty_winp))) {
+    case -1: status = errno; break;
+    case  0: ptyForkChildRoutine(cmdline); break;
+    default: ptyForkParentRoutine(pty_fd, pty_pid, &hProcess, &hThread);
+    }
+    if (status == 0) {
+        *phProcess = hProcess, *phThread = hThread;
+        m_fd = pty_fd, m_pid = pty_pid;
+        if (!m_inputWorker.startWorker() || !m_outputWorker.startWorker()) {
+            close(), status = EINVAL;
+        }
+    }
+    return status;
+}
+
+bool AgentCygwinPty::read(const char **pbuf, size_t *pbuf_len)
+{
+    std::tuple<void *, size_t, size_t> item;
+    bool itemfl = false;
+
+    EnterCriticalSection(&m_inputWorker.m_cs);
+    if (m_inputWorker.m_queue.size() > 0) {
+        item = m_inputWorker.m_queue[0], itemfl = true;
+        m_inputWorker.m_queue.erase(m_inputWorker.m_queue.begin());
+        if (m_inputWorker.m_queue.size() == 0) {
+            ResetEvent(m_inputWorker.m_event.get());
+        }
+    }
+    LeaveCriticalSection(&m_inputWorker.m_cs);
+    if (itemfl) {
+        *pbuf = (const char *)std::get<0>(item), *pbuf_len = std::get<1>(item);
+    } else {
+        *pbuf = nullptr, *pbuf_len = 0;
+    }
+    return (m_inputWorker.m_status == 0);
+}
+
+bool AgentCygwinPty::write(const char *buf, size_t buf_len)
+{
+    if (buf_len > 0) {
+        EnterCriticalSection(&m_outputWorker.m_cs);
+        m_outputWorker.m_queue.push_back(std::tuple<void *, size_t, size_t>((void *)buf, buf_len, 0));
+        m_outputWorker.wakeWorker();
+        LeaveCriticalSection(&m_outputWorker.m_cs);
+        return (m_outputWorker.m_status == 0);
+    } else {
+        return false;
+    }
+}
+
+AgentCygwinPty::IoWorker::IoWorker(AgentCygwinPty &pty) :
+    m_pty(pty), m_event(createEvent()), m_status(0)
+{
+    InitializeCriticalSection(&m_cs); ResetEvent(m_event.get());
+}
+
+AgentCygwinPty::IoWorker::~IoWorker()
+{
+    cancelWorker();
+    for (auto &item : m_queue) {
+        if (std::get<0>(item)) {
+            delete (char *)std::get<0>(item);
+        }
+    }
+}
+
+bool AgentCygwinPty::IoWorker::cancelWorker()
+{
+    if (m_hThread) {
+        EnterCriticalSection(&m_cs);
+        TerminateThread(m_hThread, 0);
+        LeaveCriticalSection(&m_cs);
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool AgentCygwinPty::IoWorker::startWorker() {
+    if (!(m_hThread = CreateThread(NULL, 0, ThreadProc, this, 0, NULL))) {
+        TRACE("CreateThread() returned nullptr");
+        return false;
+    } else {
+        return true;
+    }
+}
+
+DWORD WINAPI AgentCygwinPty::IoWorker::ThreadProc(LPVOID lpParameter)
+{
+    AgentCygwinPty::IoWorker *ioWorker = (AgentCygwinPty::IoWorker *)lpParameter;
+    return ioWorker->threadProc();
+}
+
+DWORD AgentCygwinPty::InputWorker::threadProc()
+{
+    static char buf[4096];
+    char *item_buf;
+    ssize_t nread;
+    int status = 0;
+
+    while (status == 0) {
+        //
+        // (based on mintty/src/child.c:child_proc())
+        // Pty devices on old Cygwin versions (pre 1005) deliver only 4 bytes
+        // at a time, and newer ones or MSYS2 deliver up to 256 at a time.
+        // so call read() repeatedly until we have a worthwhile haul.
+        // this avoids most partial updates, results in less flickering/tearing.
+        //
+        nread = ::read(m_pty.m_fd, buf, sizeof(buf));
+        TRACE("InputWorker::threadProc(): read %ld bytes", nread);
+        if (nread == 0) {
+            status = EPIPE;
+        } else if (nread < 0) {
+            status = errno;
+        } else {
+            item_buf = new char[nread];
+            memcpy(item_buf, buf, nread);
+            EnterCriticalSection(&m_cs);
+            m_queue.push_back(std::tuple<void *, size_t, size_t>(item_buf, nread, 0));
+            SetEvent(m_event.get());
+            LeaveCriticalSection(&m_cs);
+        }
+    }
+    m_status = status;
+    TRACE("InputWorker::threadProc(): exiting w/ status=%d", status);
+    SetEvent(m_event.get());
+    return 0;
+}
+
+bool AgentCygwinPty::OutputWorker::startWorker()
+{
+    if (pipe(m_fd_pipe) < 0) {
+        TRACE("pipe() returned -1");
+        return false;
+    } else if (!AgentCygwinPty::IoWorker::startWorker()) {
+        ::close(m_fd_pipe[0]); ::close(m_fd_pipe[1]); m_fd_pipe[0] = m_fd_pipe[1] = -1;
+        return false;
+    } else {
+        return true;
+    }
+}
+
+DWORD AgentCygwinPty::OutputWorker::threadProc()
+{
+    std::tuple<void *, size_t, size_t> item;
+    ssize_t nread, nwritten;
+    char pipe_buf[1];
+    int status = 0;
+
+    while (status == 0) {
+        if ((nread = ::read(m_fd_pipe[0], pipe_buf, sizeof(pipe_buf))) <= 0) {
+            status = (nread == 0) ? EPIPE : errno;
+        } else {
+            EnterCriticalSection(&m_cs);
+            if (m_queue.size() > 0) {
+                item = m_queue[0];
+                nwritten = ::write(m_pty.m_fd, (uint8_t *)std::get<0>(item) + std::get<2>(item), std::get<1>(item) - std::get<2>(item));
+                TRACE("OutputWorker::threadProc(): wrote %ld bytes", nwritten);
+                if ((nwritten > 0) && ((size_t)nwritten == (std::get<1>(item) + std::get<2>(item)))) {
+                    m_queue.erase(m_queue.begin());
+                } else if ((nwritten > 0) && ((size_t)nwritten < (std::get<1>(item) + std::get<2>(item)))) {
+                    std::get<2>(item) += nwritten;
+                } else if (nwritten < 0) {
+                    status = errno;
+                }
+            }
+            LeaveCriticalSection(&m_cs);
+        }
+    }
+    m_status = status;
+    TRACE("OutputWorker::threadProc(): exiting w/ status=%d", status);
+    return 0;
+}
+
+bool AgentCygwinPty::OutputWorker::wakeWorker()
+{
+    bool rc = false;
+
+    if (m_fd_pipe[1] != -1) {
+        rc = ::write(m_fd_pipe[1], "", 1) == 1;
+    }
+    return rc;
+}

--- a/src/cygwin-agent/AgentCygwinPty.h
+++ b/src/cygwin-agent/AgentCygwinPty.h
@@ -1,0 +1,99 @@
+// Copyright (c) 2011-2015 Ryan Prichard
+// Copyright (c) 2019 Lucio Andrés Illanes Albornoz <lucio@lucioillanes.de>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#ifndef AGENT_CYGWIN_PTY_H
+#define AGENT_CYGWIN_PTY_H
+
+#include <windows.h>
+
+#include <termios.h>
+
+#include <atomic>
+#include <tuple>
+#include <vector>
+
+#include "../shared/OwnedHandle.h"
+#include "EventLoop.h"
+
+class EventLoop;
+
+class AgentCygwinPty
+{
+private:
+    friend class EventLoop;
+
+    class IoWorker
+    {
+    protected:
+        static DWORD WINAPI ThreadProc(LPVOID lpParameter);
+        virtual DWORD threadProc() = 0;
+
+        HANDLE m_hThread = nullptr;
+        AgentCygwinPty &m_pty;
+
+    public:
+        IoWorker(AgentCygwinPty &pty);
+        ~IoWorker();
+        bool cancelWorker();
+        virtual bool startWorker();
+
+        CRITICAL_SECTION m_cs;
+        OwnedHandle m_event;
+        std::vector<std::tuple<void *, size_t, size_t>> m_queue;
+        std::atomic<int> m_status;
+    };
+
+    class InputWorker : public IoWorker
+    {
+    protected:
+        DWORD threadProc();
+    public:
+        InputWorker(AgentCygwinPty &pty) : IoWorker(pty) {}
+    };
+
+    class OutputWorker : public IoWorker
+    {
+    private:
+        int m_fd_pipe[2] = {-1, -1};
+    protected:
+        DWORD threadProc();
+    public:
+        OutputWorker(AgentCygwinPty &pty) : IoWorker(pty) {}
+        bool startWorker();
+        bool wakeWorker();
+    };
+
+public:
+    AgentCygwinPty() : m_inputWorker(*this), m_outputWorker(*this) {}
+    ~AgentCygwinPty() {close();}
+
+    void close();
+    int fork(const std::wstring cmdline, struct winsize pty_winp, HANDLE *phProcess, HANDLE *phThread);
+    bool read(const char **pbuf, size_t *pbuf_len);
+    bool write(const char *buf, size_t buf_len);
+
+    int m_fd = -1;
+    InputWorker m_inputWorker;
+    OutputWorker m_outputWorker;
+    pid_t m_pid = -1;
+};
+
+#endif // AGENT_CYGWIN_PTY_H

--- a/src/cygwin-agent/EventLoop.cc
+++ b/src/cygwin-agent/EventLoop.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2011-2012 Ryan Prichard
+// Copyright (c) 2019 Lucio Andrés Illanes Albornoz <lucio@lucioillanes.de>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#include "EventLoop.h"
+
+#include "NamedPipe.h"
+#include "../shared/DebugClient.h"
+#include "../shared/WinptyAssert.h"
+
+EventLoop::~EventLoop() {
+    for (NamedPipe *pipe : m_pipes) {
+        delete pipe;
+    }
+    m_pipes.clear();
+}
+
+NamedPipe &EventLoop::createNamedPipe()
+{
+    NamedPipe *ret = new NamedPipe();
+    m_pipes.push_back(ret);
+    return *ret;
+}
+
+// Enter the event loop.  Runs until the I/O or timeout handler calls exit().
+void EventLoop::run()
+{
+    bool didSomething = false;
+    HANDLE hEvent;
+    std::vector<HANDLE> waitHandles;
+    while (!m_exiting) {
+        didSomething = false;
+
+        // Attempt to make progress with the pipes.
+        waitHandles.clear();
+        for (size_t i = 0; i < m_pipes.size(); ++i) {
+            if (m_pipes[i]->serviceIo(&waitHandles)) {
+                onPipeIo(*m_pipes[i]);
+                didSomething = true;
+            }
+        }
+
+        // Attempt to make progress with the pty.
+        didSomething = onPtyIo();
+        if ((hEvent = getPtyEventHandle())) {
+            waitHandles.insert(waitHandles.end(), hEvent);
+        }
+
+        if (didSomething)
+            continue;
+
+        // If there's nothing to do, wait.
+        DWORD timeout = INFINITE;
+        if (waitHandles.size() == 0) {
+            ASSERT(timeout != INFINITE);
+            if (timeout > 0)
+                Sleep(timeout);
+        } else {
+            DWORD result = WaitForMultipleObjects(waitHandles.size(),
+                                                  waitHandles.data(),
+                                                  FALSE,
+                                                  timeout);
+            ASSERT(result != WAIT_FAILED);
+        }
+    }
+
+    // Attempt to flush pipe queues.
+    do {
+        didSomething = false;
+        for (size_t i = 0; i < m_pipes.size(); ++i) {
+            if (m_pipes[i]->serviceIo(&waitHandles)) {
+                onPipeIo(*m_pipes[i]);
+                didSomething = true;
+            }
+        }
+    } while (didSomething);
+}
+
+void EventLoop::shutdown()
+{
+    m_exiting = true;
+}

--- a/src/cygwin-agent/EventLoop.cc
+++ b/src/cygwin-agent/EventLoop.cc
@@ -57,6 +57,9 @@ void EventLoop::run()
             }
         }
 
+        if (didSomething)
+            continue;
+
         // Attempt to make progress with the pty.
         didSomething = onPtyIo();
         if ((hEvent = getPtyEventHandle())) {

--- a/src/cygwin-agent/EventLoop.h
+++ b/src/cygwin-agent/EventLoop.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2011-2012 Ryan Prichard
+// Copyright (c) 2019 Lucio Andrés Illanes Albornoz <lucio@lucioillanes.de>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#ifndef EVENTLOOP_H
+#define EVENTLOOP_H
+
+#include <windows.h>
+
+#include <vector>
+
+class NamedPipe;
+
+class EventLoop
+{
+public:
+    virtual ~EventLoop();
+    void run();
+    void createNamedPipe(NamedPipe &namedPipe);
+    bool m_exiting = false;
+
+protected:
+    NamedPipe &createNamedPipe();
+    void shutdown();
+    virtual HANDLE getPtyEventHandle()              {return nullptr;}
+    virtual bool onPtyIo()                          {return false;}
+    virtual void onPipeIo(NamedPipe &namedPipe)     {(void)namedPipe;}
+
+private:
+    std::vector<NamedPipe*> m_pipes;
+};
+
+#endif // EVENTLOOP_H

--- a/src/cygwin-agent/NamedPipe.cc
+++ b/src/cygwin-agent/NamedPipe.cc
@@ -1,0 +1,378 @@
+// Copyright (c) 2011-2012 Ryan Prichard
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#include <string.h>
+
+#include <algorithm>
+
+#include "EventLoop.h"
+#include "NamedPipe.h"
+#include "../shared/DebugClient.h"
+#include "../shared/StringUtil.h"
+#include "../shared/WindowsSecurity.h"
+#include "../shared/WinptyAssert.h"
+
+// Returns true if anything happens (data received, data sent, pipe error).
+bool NamedPipe::serviceIo(std::vector<HANDLE> *waitHandles)
+{
+    bool justConnected = false;
+    const auto kError = ServiceResult::Error;
+    const auto kProgress = ServiceResult::Progress;
+    const auto kNoProgress = ServiceResult::NoProgress;
+    if (m_handle == NULL) {
+        return false;
+    }
+    if (m_connectEvent.get() != nullptr) {
+        // We're still connecting this server pipe.  Check whether the pipe is
+        // now connected.  If it isn't, add the pipe to the list of handles to
+        // wait on.
+        DWORD actual = 0;
+        BOOL success =
+            GetOverlappedResult(m_handle, &m_connectOver, &actual, FALSE);
+        if (!success && GetLastError() == ERROR_PIPE_CONNECTED) {
+            // I'm not sure this can happen, but it's easy to handle if it
+            // does.
+            success = TRUE;
+        }
+        if (!success) {
+            ASSERT(GetLastError() == ERROR_IO_INCOMPLETE &&
+                "Pended ConnectNamedPipe call failed");
+            waitHandles->push_back(m_connectEvent.get());
+        } else {
+            TRACE("Server pipe [%s] connected",
+                utf8FromWide(m_name).c_str());
+            m_connectEvent.dispose();
+            startPipeWorkers();
+            justConnected = true;
+        }
+    }
+    const auto readProgress = m_inputWorker ? m_inputWorker->service() : kNoProgress;
+    const auto writeProgress = m_outputWorker ? m_outputWorker->service() : kNoProgress;
+    if (readProgress == kError || writeProgress == kError) {
+        closePipe();
+        return true;
+    }
+    if (m_inputWorker && m_inputWorker->getWaitEvent() != nullptr) {
+        waitHandles->push_back(m_inputWorker->getWaitEvent());
+    }
+    if (m_outputWorker && m_outputWorker->getWaitEvent() != nullptr) {
+        waitHandles->push_back(m_outputWorker->getWaitEvent());
+    }
+    return justConnected
+        || readProgress == kProgress
+        || writeProgress == kProgress;
+}
+
+// manual reset, initially unset
+static OwnedHandle createEvent() {
+    HANDLE ret = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    ASSERT(ret != nullptr && "CreateEventW failed");
+    return OwnedHandle(ret);
+}
+
+NamedPipe::IoWorker::IoWorker(NamedPipe &namedPipe) :
+    m_namedPipe(namedPipe),
+    m_event(createEvent())
+{
+}
+
+NamedPipe::ServiceResult NamedPipe::IoWorker::service()
+{
+    ServiceResult progress = ServiceResult::NoProgress;
+    if (m_pending) {
+        DWORD actual = 0;
+        BOOL ret = GetOverlappedResult(m_namedPipe.m_handle, &m_over, &actual, FALSE);
+        if (!ret) {
+            if (GetLastError() == ERROR_IO_INCOMPLETE) {
+                // There is a pending I/O.
+                return progress;
+            } else {
+                // Pipe error.
+                return ServiceResult::Error;
+            }
+        }
+        ResetEvent(m_event.get());
+        m_pending = false;
+        completeIo(actual);
+        m_currentIoSize = 0;
+        progress = ServiceResult::Progress;
+    }
+    DWORD nextSize = 0;
+    bool isRead = false;
+    while (shouldIssueIo(&nextSize, &isRead)) {
+        m_currentIoSize = nextSize;
+        DWORD actual = 0;
+        memset(&m_over, 0, sizeof(m_over));
+        m_over.hEvent = m_event.get();
+        BOOL ret = isRead
+                ? ReadFile(m_namedPipe.m_handle, m_buffer, nextSize, &actual, &m_over)
+                : WriteFile(m_namedPipe.m_handle, m_buffer, nextSize, &actual, &m_over);
+        if (!ret) {
+            if (GetLastError() == ERROR_IO_PENDING) {
+                // There is a pending I/O.
+                m_pending = true;
+                return progress;
+            } else {
+                // Pipe error.
+                return ServiceResult::Error;
+            }
+        }
+        ResetEvent(m_event.get());
+        completeIo(actual);
+        m_currentIoSize = 0;
+        progress = ServiceResult::Progress;
+    }
+    return progress;
+}
+
+// This function is called after CancelIo has returned.  We need to block until
+// the I/O operations have completed, which should happen very quickly.
+// https://blogs.msdn.microsoft.com/oldnewthing/20110202-00/?p=11613
+void NamedPipe::IoWorker::waitForCanceledIo()
+{
+    if (m_pending) {
+        DWORD actual = 0;
+        GetOverlappedResult(m_namedPipe.m_handle, &m_over, &actual, TRUE);
+        m_pending = false;
+    }
+}
+
+HANDLE NamedPipe::IoWorker::getWaitEvent()
+{
+    return m_pending ? m_event.get() : NULL;
+}
+
+void NamedPipe::InputWorker::completeIo(DWORD size)
+{
+    m_namedPipe.m_inQueue.append(m_buffer, size);
+}
+
+bool NamedPipe::InputWorker::shouldIssueIo(DWORD *size, bool *isRead)
+{
+    *isRead = true;
+    ASSERT(!m_namedPipe.isConnecting());
+    if (m_namedPipe.isClosed()) {
+        return false;
+    } else if (m_namedPipe.m_inQueue.size() < m_namedPipe.readBufferSize()) {
+        *size = kIoSize;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+void NamedPipe::OutputWorker::completeIo(DWORD size)
+{
+    ASSERT(size == m_currentIoSize);
+}
+
+bool NamedPipe::OutputWorker::shouldIssueIo(DWORD *size, bool *isRead)
+{
+    *isRead = false;
+    if (!m_namedPipe.m_outQueue.empty()) {
+        auto &out = m_namedPipe.m_outQueue;
+        const DWORD writeSize = std::min<size_t>(out.size(), kIoSize);
+        std::copy(&out[0], &out[writeSize], m_buffer);
+        out.erase(0, writeSize);
+        *size = writeSize;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+DWORD NamedPipe::OutputWorker::getPendingIoSize()
+{
+    return m_pending ? m_currentIoSize : 0;
+}
+
+void NamedPipe::openServerPipe(LPCWSTR pipeName, OpenMode::t openMode,
+                               int outBufferSize, int inBufferSize) {
+    ASSERT(isClosed());
+    ASSERT((openMode & OpenMode::Duplex) != 0);
+    const DWORD winOpenMode =
+              ((openMode & OpenMode::Reading) ? PIPE_ACCESS_INBOUND : 0)
+            | ((openMode & OpenMode::Writing) ? PIPE_ACCESS_OUTBOUND : 0)
+            | FILE_FLAG_FIRST_PIPE_INSTANCE
+            | FILE_FLAG_OVERLAPPED;
+    const auto sd = createPipeSecurityDescriptorOwnerFullControl();
+    ASSERT(sd && "error creating data pipe SECURITY_DESCRIPTOR");
+    SECURITY_ATTRIBUTES sa = {};
+    sa.nLength = sizeof(sa);
+    sa.lpSecurityDescriptor = sd.get();
+    HANDLE handle = CreateNamedPipeW(
+        pipeName,
+        /*dwOpenMode=*/winOpenMode,
+        /*dwPipeMode=*/rejectRemoteClientsPipeFlag(),
+        /*nMaxInstances=*/1,
+        /*nOutBufferSize=*/outBufferSize,
+        /*nInBufferSize=*/inBufferSize,
+        /*nDefaultTimeOut=*/30000,
+        &sa);
+    TRACE("opened server pipe [%s], handle == %p",
+        utf8FromWide(pipeName).c_str(), handle);
+    ASSERT(handle != INVALID_HANDLE_VALUE && "Could not open server pipe");
+    m_name = pipeName;
+    m_handle = handle;
+    m_openMode = openMode;
+
+    // Start an asynchronous connection attempt.
+    m_connectEvent = createEvent();
+    memset(&m_connectOver, 0, sizeof(m_connectOver));
+    m_connectOver.hEvent = m_connectEvent.get();
+    BOOL success = ConnectNamedPipe(m_handle, &m_connectOver);
+    const auto err = GetLastError();
+    if (!success && err == ERROR_PIPE_CONNECTED) {
+        success = TRUE;
+    }
+    if (success) {
+        TRACE("Server pipe [%s] connected", utf8FromWide(pipeName).c_str());
+        m_connectEvent.dispose();
+        startPipeWorkers();
+    } else if (err != ERROR_IO_PENDING) {
+        ASSERT(false && "ConnectNamedPipe call failed");
+    }
+}
+
+void NamedPipe::connectToServer(LPCWSTR pipeName, OpenMode::t openMode)
+{
+    ASSERT(isClosed());
+    ASSERT((openMode & OpenMode::Duplex) != 0);
+    HANDLE handle = CreateFileW(
+        pipeName,
+        GENERIC_READ | GENERIC_WRITE,
+        0,
+        NULL,
+        OPEN_EXISTING,
+        SECURITY_SQOS_PRESENT | SECURITY_IDENTIFICATION | FILE_FLAG_OVERLAPPED,
+        NULL);
+    TRACE("connected to [%s], handle == %p",
+        utf8FromWide(pipeName).c_str(), handle);
+    ASSERT(handle != INVALID_HANDLE_VALUE && "Could not connect to pipe");
+    m_name = pipeName;
+    m_handle = handle;
+    m_openMode = openMode;
+    startPipeWorkers();
+}
+
+void NamedPipe::startPipeWorkers()
+{
+    if (m_openMode & OpenMode::Reading) {
+        m_inputWorker.reset(new InputWorker(*this));
+    }
+    if (m_openMode & OpenMode::Writing) {
+        m_outputWorker.reset(new OutputWorker(*this));
+    }
+}
+
+size_t NamedPipe::bytesToSend()
+{
+    ASSERT(m_openMode & OpenMode::Writing);
+    auto ret = m_outQueue.size();
+    if (m_outputWorker != NULL) {
+        ret += m_outputWorker->getPendingIoSize();
+    }
+    return ret;
+}
+
+void NamedPipe::write(const void *data, size_t size)
+{
+    ASSERT(m_openMode & OpenMode::Writing);
+    m_outQueue.append(reinterpret_cast<const char*>(data), size);
+}
+
+void NamedPipe::write(const char *text)
+{
+    write(text, strlen(text));
+}
+
+size_t NamedPipe::readBufferSize()
+{
+    ASSERT(m_openMode & OpenMode::Reading);
+    return m_readBufferSize;
+}
+
+void NamedPipe::setReadBufferSize(size_t size)
+{
+    ASSERT(m_openMode & OpenMode::Reading);
+    m_readBufferSize = size;
+}
+
+size_t NamedPipe::bytesAvailable()
+{
+    ASSERT(m_openMode & OpenMode::Reading);
+    return m_inQueue.size();
+}
+
+size_t NamedPipe::peek(void *data, size_t size)
+{
+    ASSERT(m_openMode & OpenMode::Reading);
+    const auto out = reinterpret_cast<char*>(data);
+    const size_t ret = std::min(size, m_inQueue.size());
+    std::copy(&m_inQueue[0], &m_inQueue[ret], out);
+    return ret;
+}
+
+size_t NamedPipe::read(void *data, size_t size)
+{
+    size_t ret = peek(data, size);
+    m_inQueue.erase(0, ret);
+    return ret;
+}
+
+std::string NamedPipe::readToString(size_t size)
+{
+    ASSERT(m_openMode & OpenMode::Reading);
+    size_t retSize = std::min(size, m_inQueue.size());
+    std::string ret = m_inQueue.substr(0, retSize);
+    m_inQueue.erase(0, retSize);
+    return ret;
+}
+
+std::string NamedPipe::readAllToString()
+{
+    ASSERT(m_openMode & OpenMode::Reading);
+    std::string ret = m_inQueue;
+    m_inQueue.clear();
+    return ret;
+}
+
+void NamedPipe::closePipe()
+{
+    if (m_handle == NULL) {
+        return;
+    }
+    CancelIo(m_handle);
+    if (m_connectEvent.get() != nullptr) {
+        DWORD actual = 0;
+        GetOverlappedResult(m_handle, &m_connectOver, &actual, TRUE);
+        m_connectEvent.dispose();
+    }
+    if (m_inputWorker) {
+        m_inputWorker->waitForCanceledIo();
+        m_inputWorker.reset();
+    }
+    if (m_outputWorker) {
+        m_outputWorker->waitForCanceledIo();
+        m_outputWorker.reset();
+    }
+    CloseHandle(m_handle);
+    m_handle = NULL;
+}

--- a/src/cygwin-agent/NamedPipe.h
+++ b/src/cygwin-agent/NamedPipe.h
@@ -1,0 +1,125 @@
+// Copyright (c) 2011-2012 Ryan Prichard
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#ifndef NAMEDPIPE_H
+#define NAMEDPIPE_H
+
+#include <windows.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "../shared/OwnedHandle.h"
+
+class EventLoop;
+
+class NamedPipe
+{
+private:
+    // The EventLoop uses these private members.
+    friend class EventLoop;
+    NamedPipe() {}
+    ~NamedPipe() { closePipe(); }
+    bool serviceIo(std::vector<HANDLE> *waitHandles);
+    void startPipeWorkers();
+
+    enum class ServiceResult { NoProgress, Error, Progress };
+
+private:
+    class IoWorker
+    {
+    public:
+        IoWorker(NamedPipe &namedPipe);
+        virtual ~IoWorker() {}
+        ServiceResult service();
+        void waitForCanceledIo();
+        HANDLE getWaitEvent();
+    protected:
+        NamedPipe &m_namedPipe;
+        bool m_pending = false;
+        DWORD m_currentIoSize = 0;
+        OwnedHandle m_event;
+        OVERLAPPED m_over = {};
+        enum { kIoSize = 64 * 1024 };
+        char m_buffer[kIoSize];
+        virtual void completeIo(DWORD size) = 0;
+        virtual bool shouldIssueIo(DWORD *size, bool *isRead) = 0;
+    };
+
+    class InputWorker : public IoWorker
+    {
+    public:
+        InputWorker(NamedPipe &namedPipe) : IoWorker(namedPipe) {}
+    protected:
+        virtual void completeIo(DWORD size) override;
+        virtual bool shouldIssueIo(DWORD *size, bool *isRead) override;
+    };
+
+    class OutputWorker : public IoWorker
+    {
+    public:
+        OutputWorker(NamedPipe &namedPipe) : IoWorker(namedPipe) {}
+        DWORD getPendingIoSize();
+    protected:
+        virtual void completeIo(DWORD size) override;
+        virtual bool shouldIssueIo(DWORD *size, bool *isRead) override;
+    };
+
+public:
+    struct OpenMode {
+        typedef int t;
+        enum { None = 0, Reading = 1, Writing = 2, Duplex = 3 };
+    };
+
+    std::wstring name() const { return m_name; }
+    void openServerPipe(LPCWSTR pipeName, OpenMode::t openMode,
+                        int outBufferSize, int inBufferSize);
+    void connectToServer(LPCWSTR pipeName, OpenMode::t openMode);
+    size_t bytesToSend();
+    void write(const void *data, size_t size);
+    void write(const char *text);
+    size_t readBufferSize();
+    void setReadBufferSize(size_t size);
+    size_t bytesAvailable();
+    size_t peek(void *data, size_t size);
+    size_t read(void *data, size_t size);
+    std::string readToString(size_t size);
+    std::string readAllToString();
+    void closePipe();
+    bool isClosed() { return m_handle == nullptr; }
+    bool isConnected() { return !isClosed() && !isConnecting(); }
+    bool isConnecting() { return m_connectEvent.get() != nullptr; }
+
+private:
+    // Input/output buffers
+    std::wstring m_name;
+    OVERLAPPED m_connectOver = {};
+    OwnedHandle m_connectEvent;
+    OpenMode::t m_openMode = OpenMode::None;
+    size_t m_readBufferSize = 64 * 1024;
+    std::string m_inQueue;
+    std::string m_outQueue;
+    HANDLE m_handle = nullptr;
+    std::unique_ptr<InputWorker> m_inputWorker;
+    std::unique_ptr<OutputWorker> m_outputWorker;
+};
+
+#endif // NAMEDPIPE_H

--- a/src/cygwin-agent/subdir.mk
+++ b/src/cygwin-agent/subdir.mk
@@ -1,0 +1,53 @@
+# Copyright (c) 2011-2015 Ryan Prichard
+# Copyright (c) 2019 Lucio Andrés Illanes Albornoz <lucio@lucioillanes.de>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+ALL_TARGETS += build/winpty-cygwin-agent.exe
+
+$(eval $(call def_unix_target,cygwin-agent,-DWINPTY_AGENT_ASSERT))
+
+CYGWIN_AGENT_OBJECTS = \
+	build/cygwin-agent/agent/DebugShowInput.o \
+	build/cygwin-agent/agent/InputMap.o \
+	build/cygwin-agent/agent/main.o \
+	build/cygwin-agent/cygwin-agent/Agent.o \
+	build/cygwin-agent/cygwin-agent/AgentCreateDesktop.o \
+	build/cygwin-agent/cygwin-agent/AgentCygwinPty.o \
+	build/cygwin-agent/cygwin-agent/EventLoop.o \
+	build/cygwin-agent/cygwin-agent/NamedPipe.o \
+	build/cygwin-agent/shared/BackgroundDesktop.o \
+	build/cygwin-agent/shared/Buffer.o \
+	build/cygwin-agent/shared/DebugClient.o \
+	build/cygwin-agent/shared/GenRandom.o \
+	build/cygwin-agent/shared/OwnedHandle.o \
+	build/cygwin-agent/shared/StringUtil.o \
+	build/cygwin-agent/shared/WindowsSecurity.o \
+	build/cygwin-agent/shared/WindowsVersion.o \
+	build/cygwin-agent/shared/WinptyAssert.o \
+	build/cygwin-agent/shared/WinptyException.o \
+	build/cygwin-agent/shared/WinptyVersion.o
+
+build/cygwin-agent/shared/WinptyVersion.o : build/gen/GenVersion.h
+
+build/winpty-cygwin-agent.exe : $(CYGWIN_AGENT_OBJECTS) build/winpty.dll
+	$(info Linking $@)
+	@$(UNIX_CXX) $(UNIX_LDFLAGS) -o $@ $^
+
+-include $(CYGWIN_AGENT_OBJECTS:.o=.d)

--- a/src/subdir.mk
+++ b/src/subdir.mk
@@ -1,4 +1,5 @@
 include src/agent/subdir.mk
+include src/cygwin-agent/subdir.mk
 include src/debugserver/subdir.mk
 include src/libwinpty/subdir.mk
 include src/tests/subdir.mk


### PR DESCRIPTION
The integrated terminal in Visual Studio Code has numerous flaws[1] on Windows and winpty versions lacking ConPTY support, which covers the lion's share of installations, as ConPTY is only available on recent Windows 10 builds.

Since winpty is ordinarily obliged to interact with Cygwin processes' terminal via Windows' deficient console APIs, this commit implements a new Cygwin adapter, on the basis of the Unix adapter, which instead leverages Cygwin's native PTY implementation. This provides a direct interface between xterm.js and Cygwin processes, addressing most of those flaws and rendering the terminal usable.

[1] https://github.com/microsoft/vscode/issues/45693