### PR TITLE
Add a solution upgrading act into the build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
+.vs
 *.sln
 *.suo
+*.vcproj
 *.vcxproj
 *.vcxproj.filters
+UpgradeLog*.htm
 *.pyc
 winpty.sdf
 winpty.opensdf

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -76,9 +76,8 @@ if errorlevel 1 (
 
 REM -------------------------------------------------------------------------
 REM -- Upgrade the project.
-devenv winpty.sln /Upgrade || (
-    echo error: Solution Upgrade failed
-    exit /b 1
+devenv winpty.sln /Upgrade 2>nul || (
+    echo warning: Solution upgrade not yet succeeded
 )
 
 REM -------------------------------------------------------------------------

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -75,6 +75,13 @@ if errorlevel 1 (
 )
 
 REM -------------------------------------------------------------------------
+REM -- Upgrade the project.
+devenv winpty.sln /Upgrade || (
+    echo error: Solution Upgrade failed
+    exit /b 1
+)
+
+REM -------------------------------------------------------------------------
 REM -- Compile the project.
 
 msbuild winpty.sln /m /p:Platform=%MSVC_PLATFORM% || (


### PR DESCRIPTION
It won't break the current build process even if the `devenv.exe` does not exist while it can avoid some `MSBuild` failure and build correctly in higher versions of `Visual Studio` such as the 2019 version which I'm using.