### PR TITLE
Workaround for resizing window problem on Windows 10

### DIFF
--- a/src/agent/Scraper.cc
+++ b/src/agent/Scraper.cc
@@ -271,7 +271,18 @@ void Scraper::resizeImpl(const ConsoleScreenBufferInfo &origInfo)
     {
         // Resize the buffer to the final desired size.
         m_console.setFrozen(false);
+
+        // Workaround for the windows console crash if resizing screen so that
+        // the cursor is hidden on Windows 10.
+        // ( https://github.com/microsoft/terminal/issues/1976 )
+        const auto info = m_consoleBuffer->bufferInfo();
+        m_consoleBuffer->setCursorPosition(Coord(0, 0));
+
         m_consoleBuffer->resizeBufferRange(finalBufferSize);
+
+        // Restore cursor position from the above workaround.
+        m_consoleBuffer->setCursorPosition(Coord(info.cursorPosition().X,
+                                                 info.cursorPosition().Y));
     }
 
     {


### PR DESCRIPTION
On Windows 10, winpty crashes if resizing screen so that the cursor is hidden.
(On Windows 8.1, there is no problem.)

It seems to be concerned with the following issue.
microsoft/terminal#1976

I tried to fix this problem.

NOTE:
Some programs hosted by winpty cause this problem and others do not.
The condition is not clear ...
