### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,19 @@ it:
 winpty also recognizes a `WINPTY_SHOW_CONSOLE` environment variable.  Set it
 to 1 to prevent winpty from hiding the console window.
 
+## Building using vcpkg
+
+You can build and install winpty using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+* git clone https://github.com/Microsoft/vcpkg.git
+* cd vcpkg
+* ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+* ./vcpkg integrate install
+* ./vcpkg install winpty
+
+The winpty port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
+
 ## Copyright
 
 This project is distributed under the MIT license (see the `LICENSE` file in


### PR DESCRIPTION
Winpty is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for winpty and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build winpty, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/winpty/portfile.cmake). We try to keep the library maintained as close as possible to the original library.